### PR TITLE
BUGFIX: Apply fulltext search to facet filters

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -1155,6 +1155,15 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
             ]
         ]);
 
+        // add the query_string filter to all facets
+        if (isset($this->request['aggregations']['facets']['aggregations'])) {
+            foreach ($this->request['aggregations']['facets']['aggregations'] as $aggregationName => &$facetAggregation) {
+                $facetAggregation['filter']['bool']['must'][]['query_string'] = [
+                    'query' => $searchWord
+                ];
+            }
+        }
+
         // We automatically enable result highlighting when doing fulltext searches. It is up to the user to use this information or not use it.
         return $this->highlight(150, 2);
     }


### PR DESCRIPTION
When applying a fulltext filter like

```
{
    "query": {
        "filtered": {
            "query": {
                "bool": {
                    "must": [
                        {
                            "query_string": {
                                "query": "*the-query*"
                            }
                        }
                    ]
                }
            },
   // ...
```

Facets didn't pick up that query filter.
With this change the fulltext filter is also applied to all
configured facets.
